### PR TITLE
fix: make base64-var concurrency safe

### DIFF
--- a/Sources/Geohash/Geohash.swift
+++ b/Sources/Geohash/Geohash.swift
@@ -144,7 +144,7 @@ public extension CLLocationCoordinate2D {
 #endif
 
 public extension Geohash {
-    private static var base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+    private static let base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
     enum Direction: String {
         case n, e, s, w
 


### PR DESCRIPTION
This PR makes the `base64` variable comply with strict concurrency when changing the version 5->6 in package.swift. Otherwise the compiler throws an error and Geohash won't compile. Since it doesn't affect functionality for Swift 5 usage of the library, I considered it a low hanging fruit.